### PR TITLE
Fix deprecated libavcodec

### DIFF
--- a/include/ffmpeg_encoder_decoder/utils.hpp
+++ b/include/ffmpeg_encoder_decoder/utils.hpp
@@ -56,7 +56,7 @@ std::vector<enum AVPixelFormat> get_hwframe_transfer_formats(AVBufferRef * hwfra
 * finds formats that the encoder supports. Note that for VAAPI, this will just
 * return AV_PIX_FMT_VAAPI since it uses hardware frames.
 */
-std::vector<enum AVPixelFormat> get_encoder_formats(const AVCodec * avctx);
+std::vector<enum AVPixelFormat> get_encoder_formats(AVCodecContext *context, const AVCodec * avctx);
 /**!
 * picks from a vector of formats the "best" pixel format for a given encoder
 */

--- a/include/ffmpeg_encoder_decoder/utils.hpp
+++ b/include/ffmpeg_encoder_decoder/utils.hpp
@@ -56,7 +56,8 @@ std::vector<enum AVPixelFormat> get_hwframe_transfer_formats(AVBufferRef * hwfra
 * finds formats that the encoder supports. Note that for VAAPI, this will just
 * return AV_PIX_FMT_VAAPI since it uses hardware frames.
 */
-std::vector<enum AVPixelFormat> get_encoder_formats(AVCodecContext *context, const AVCodec * avctx);
+std::vector<enum AVPixelFormat> get_encoder_formats(
+  AVCodecContext * context, const AVCodec * avctx);
 /**!
 * picks from a vector of formats the "best" pixel format for a given encoder
 */

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -38,8 +38,9 @@ Decoder::~Decoder() { reset(); }
 void Decoder::reset()
 {
   if (codecContext_) {
-    avcodec_close(codecContext_);
-    av_free(codecContext_);
+    avcodec_free_context(&codecContext_);
+    // avcodec_close(codecContext_);
+    // av_free(codecContext_);
     codecContext_ = NULL;
   }
   if (swsContext_) {

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -54,7 +54,8 @@ static void free_frame(AVFrame ** frame)
 void Encoder::closeCodec()
 {
   if (codecContext_) {
-    avcodec_close(codecContext_);
+    avcodec_free_context(&codecContext_);
+    // avcodec_close(codecContext_);
     codecContext_ = nullptr;
   }
   free_frame(&frame_);
@@ -174,12 +175,14 @@ void Encoder::doOpenCodec(int width, int height)
     throw(std::runtime_error("cannot find encoder: " + encoder_));
   }
 
-  auto pixFmts = utils::get_encoder_formats(codec);
   // allocate codec context
   codecContext_ = avcodec_alloc_context3(codec);
   if (!codecContext_) {
     throw(std::runtime_error("cannot allocate codec context!"));
   }
+
+  auto pixFmts = utils::get_encoder_formats(codecContext_, codec);
+
   codecContext_->bit_rate = bitRate_;
   codecContext_->qmax = qmax_;  // 0: highest, 63: worst quality bound
   codecContext_->width = width;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -101,12 +101,22 @@ enum AVPixelFormat get_preferred_pixel_format(
   return (AV_PIX_FMT_NONE);
 }
 
-std::vector<enum AVPixelFormat> get_encoder_formats(const AVCodec * c)
+std::vector<enum AVPixelFormat> get_encoder_formats(AVCodecContext *context, const AVCodec * c)
 {
   std::vector<enum AVPixelFormat> formats;
-  if (c && c->pix_fmts) {
-    for (const auto * p = c->pix_fmts; *p != AV_PIX_FMT_NONE; ++p) {
-      formats.push_back(*p);
+  if (c) {
+    const enum AVPixelFormat *pix_fmts = nullptr;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
+    pix_fmts = c->pix_fmts;
+    (void) context;
+#else
+    avcodec_get_supported_config(context, c,
+            AV_CODEC_CONFIG_PIX_FORMAT, 0, (const void **) &pix_fmts, NULL);
+#endif
+    if (pix_fmts) {
+      for (const auto * p = pix_fmts; *p != AV_PIX_FMT_NONE; ++p) {
+	formats.push_back(*p);
+      }
     }
   }
   return (formats);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -101,21 +101,21 @@ enum AVPixelFormat get_preferred_pixel_format(
   return (AV_PIX_FMT_NONE);
 }
 
-std::vector<enum AVPixelFormat> get_encoder_formats(AVCodecContext *context, const AVCodec * c)
+std::vector<enum AVPixelFormat> get_encoder_formats(AVCodecContext * context, const AVCodec * c)
 {
   std::vector<enum AVPixelFormat> formats;
   if (c) {
-    const enum AVPixelFormat *pix_fmts = nullptr;
+    const enum AVPixelFormat * pix_fmts = nullptr;
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
     pix_fmts = c->pix_fmts;
-    (void) context;
+    (void)context;
 #else
-    avcodec_get_supported_config(context, c,
-            AV_CODEC_CONFIG_PIX_FORMAT, 0, (const void **) &pix_fmts, NULL);
+    avcodec_get_supported_config(
+      context, c, AV_CODEC_CONFIG_PIX_FORMAT, 0, (const void **)&pix_fmts, NULL);
 #endif
     if (pix_fmts) {
       for (const auto * p = pix_fmts; *p != AV_PIX_FMT_NONE; ++p) {
-	formats.push_back(*p);
+        formats.push_back(*p);
       }
     }
   }


### PR DESCRIPTION
This PR fixes warnings (and resulting build errors) for the latest version (7.x) of libavcodec