### PR TITLE
When using CMake >= 3.24 use CMAKE_COMPILE_WARNING_AS_ERROR variable instead of setting `-Werror` directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,13 @@
 cmake_minimum_required(VERSION 3.16)
 project(ffmpeg_encoder_decoder)
 
-add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+add_compile_options(-Wall -Wextra -Wpedantic)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
+  option(CMAKE_COMPILE_WARNING_AS_ERROR "Treat compiler warnings as errors." ON)
+  mark_as_advanced(CMAKE_COMPILE_WARNING_AS_ERROR)
+else()
+  add_compile_options(-Werror)
+endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
The `-Werror` option is typically enabled automatically by library authors, so they ensure that all contributors to the library early fail if new code they write contain a warning, ensuring as soon as possible that no new warnings are added to the library. On the other hand, people that package libraries for distributions prefer to disable the `-Werror` option, as they may want to compile a given library with a new compilers (that may not have even existed when a given release of a library was tagged), that introduce new warnings, without having a failure. For a detailed discussion of this from the point of view of people packaging libraries, see https://youtu.be/_5weX5mx8hc?si=ZtiWaK7KPTfQ01_g&t=322 .

Thanks to the [`CMAKE_COMPILE_WARNING_AS_ERROR`](https://cmake.org/cmake/help/latest/prop_tgt/COMPILE_WARNING_AS_ERROR.html) CMake option available since CMake 3.24, it is possible to have the best of both worlds. Library authors can define this variable as an option and have it `ON` by default, while people packaging libraries can just set it to `OFF` from CMake command line invocation (or pass [`--compile-no-warning-as-error`](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-compile-no-warning-as-error) option to CMake) to have build scripts that will work also with more recent compilers.