### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,17 +80,16 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(${PROJECT_NAME}
-PUBLIC
-  cv_bridge
-  rclcpp
-  sensor_msgs
-)
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
     opencv_imgproc
-    PkgConfig::LIBAV)
+    PkgConfig::LIBAV
+    ${sensor_msgs_TARGETS}
+    cv_bridge::cv_bridge
+    rclcpp::rclcpp
+    sensor_msgs::sensor_msgs_library
+)
 
 
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,11 +80,12 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
 PUBLIC
   cv_bridge
   rclcpp
-  sensor_msgs)
+  sensor_msgs
+)
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
