### PR TITLE
preserve PKG_CONFIG_PATH instead of overwriting it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,26 +40,11 @@ set(FFMPEG_PKGCONFIG "" CACHE STRING "extra path to pkgconfig")
 if("${FFMPEG_PKGCONFIG}" STREQUAL "")
 else()
   message(WARNING "using FFMPEG package from ${FFMPEG_PKGCONFIG}")
+  set(ENV{PKG_CONFIG_PATH} "${FFMPEG_PKGCONFIG}:$ENV{PKG_CONFIG_PATH}")
 endif()
 
-set(ENV{PKG_CONFIG_PATH} ${FFMPEG_PKGCONFIG})
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
-    libavcodec
-    libswresample
-    libswscale
-    libavutil)
-
-
-set(FFMPEG_PKGCONFIG "" CACHE STRING "extra path to pkgconfig")
-if("${FFMPEG_PKGCONFIG}" STREQUAL "")
-else()
-  message(WARNING "using FFMPEG package from ${FFMPEG_PKGCONFIG}")
-endif()
-
-set(ENV{PKG_CONFIG_PATH} ${FFMPEG_PKGCONFIG})
-find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
     libavcodec
     libswresample

--- a/cmake/ffmpeg_encoder_decoder-extras.cmake.in
+++ b/cmake/ffmpeg_encoder_decoder-extras.cmake.in
@@ -1,5 +1,7 @@
 set(FFMPEG_PKGCONFIG "" CACHE STRING "extra path to pkgconfig")
-set(ENV{PKG_CONFIG_PATH} ${FFMPEG_PKGCONFIG})
+if(NOT "${FFMPEG_PKGCONFIG}" STREQUAL "")
+  set(ENV{PKG_CONFIG_PATH} "${FFMPEG_PKGCONFIG}:$ENV{PKG_CONFIG_PATH}")
+endif()
 
 find_package(PkgConfig REQUIRED)
 


### PR DESCRIPTION
Hi! I've come across this repo as a depenency for foxglove_compressed_video_transport - thanks for your work on both!

**The Problem:**
`set(ENV{PKG_CONFIG_PATH} ${FFMPEG_PKGCONFIG})` unconditionally overwrites `PKG_CONFIG_PATH`. Since `FFMPEG_PKGCONFIG` defaults to an empty string, this blanks out the entire variable during cmake configure.

This works on Ubuntu by accident because ffmpeg's `.pc` files live in pkg-config's default search path. But it breaks when using Nix or cross-compilation setups.

**Proposed fix:**
- Prepend `FFMPEG_PKGCONFIG` to `PKG_CONFIG_PATH` instead of replacing it, and only when it's non-empty

I also removed a duplicated pkg-config discovery block in `CMakeLists.txt`

