### PR TITLE
Use portable bit-rate logging in ffmpeg_encoder_decoder

### DIFF
--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -21,6 +21,7 @@
 #include <cv_bridge/cv_bridge.h>
 #endif
 
+#include <cinttypes>
 #include <ffmpeg_encoder_decoder/safe_param.hpp>
 #include <ffmpeg_encoder_decoder/utils.hpp>
 #include <fstream>
@@ -260,8 +261,8 @@ void Encoder::doOpenCodec(int width, int height, const std::string & origEncodin
     ss << " " << kv.first << "=" << kv.second;
   }
   RCLCPP_INFO(
-    logger_, "codec: %10s, bit_rate: %10ld qmax: %2d options: %s", encoder_.c_str(), bitRate_,
-    qmax_, ss.str().c_str());
+    logger_, "codec: %10s, bit_rate: %10" PRId64 " qmax: %2d options: %s", encoder_.c_str(),
+    bitRate_, qmax_, ss.str().c_str());
   RCLCPP_INFO_STREAM(
     logger_, "cv_bridge_target_format: "
                << cvBridgeTargetFormat_


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-ffmpeg-encoder-decoder.unix.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: bitRate_ is int64_t, so logging it through a long-specific format can warn or fail on platforms where long and int64_t differ; casting to long long with a matching format keeps the log statement portable.
